### PR TITLE
update MWAA requirements version when updating requirements file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL version="0.1.0"
 # https://github.com/aws/aws-cli/blob/master/CHANGELOG.rst
 ENV AWSCLI_VERSION='2.3.6'
 
-RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION}
+RUN pip install --quiet --no-cache-dir awscliv2==${AWSCLI_VERSION}
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ LABEL version="0.1.0"
 ENV GLIBC_VER=2.31-r0
 ENV AWS_CLI_VER=2.3.6
 
-# install glibc compatibility for alpine
+# We need AWS CLI v2 but it isn't compatible out-of-the-box with alpine so we
+# have to do this magic.
+# For more info: https://stackoverflow.com/questions/61463584/docker-image-with-aws-cli-v2-and-dind-based-on-alpine3-11
 RUN apk --no-cache add \
         binutils \
         curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-alpine
 LABEL version="0.1.0"
 
 ENV GLIBC_VER=2.31-r0
-AWS_CLI_VER='2.3.6'
+ENV AWS_CLI_VER=2.3.6
 
 # install glibc compatibility for alpine
 RUN apk --no-cache add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-alpine
 LABEL version="0.1.0"
 
 # https://github.com/aws/aws-cli/blob/master/CHANGELOG.rst
-ENV AWSCLI_VERSION='1.16.237'
+ENV AWSCLI_VERSION='2.3.6'
 
 RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-alpine
 LABEL version="0.1.0"
 
 # https://github.com/aws/aws-cli/blob/master/CHANGELOG.rst
-ENV AWSCLI_VERSION='2.3.6'
+ENV AWSCLI_VERSION='1.5.2'
 
 RUN pip install --quiet --no-cache-dir awscliv2==${AWSCLI_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,37 @@ FROM python:3.6-alpine
 
 LABEL version="0.1.0"
 
-# https://github.com/aws/aws-cli/blob/master/CHANGELOG.rst
-ENV AWSCLI_VERSION='1.5.2'
+ENV GLIBC_VER=2.31-r0
+AWS_CLI_VER='2.3.6'
 
-RUN pip install --quiet --no-cache-dir awscliv2==${AWSCLI_VERSION}
+# install glibc compatibility for alpine
+RUN apk --no-cache add \
+        binutils \
+        curl \
+    && curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk \
+    && curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk \
+    && apk add --no-cache \
+        glibc-${GLIBC_VER}.apk \
+        glibc-bin-${GLIBC_VER}.apk \
+        glibc-i18n-${GLIBC_VER}.apk \
+    && /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8 \
+    && curl -sL https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VER}.zip -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && aws/install \
+    && rm -rf \
+        awscliv2.zip \
+        aws \
+        /usr/local/aws-cli/v2/current/dist/aws_completer \
+        /usr/local/aws-cli/v2/current/dist/awscli/data/ac.index \
+        /usr/local/aws-cli/v2/current/dist/awscli/examples \
+        glibc-*.apk \
+    && find /usr/local/aws-cli/v2/current/dist/awscli/botocore/data -name examples-1.json -delete \
+    && apk --no-cache del \
+        binutils \
+        curl \
+    && rm -rf /var/cache/apk/*
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: turnerlabs/s3-sync-airflow-action@master
+    - uses: PromiseNetwork/s3-sync-airflow-action@master
       env:
         SOURCE_DIR: ${{ github.workspace }}
         AWS_DEFAULT_REGION: 'us-east-1'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@
 set -e
 
 alias aws='awsv2'
+aws --install
 
 if [ -z "$AWS_S3_BUCKET" ]; then
   echo "AWS_S3_BUCKET is not set. Quitting."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-aws --version
-
 if [ -z "$AWS_S3_BUCKET" ]; then
   echo "AWS_S3_BUCKET is not set. Quitting."
   exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ if [ -d "$SOURCE_DIR/requirements" ]; then
     aws s3 sync ${SOURCE_DIR}/requirements s3://${AWS_S3_BUCKET}/requirements --exact-timestamps --delete --region ${AWS_DEFAULT_REGION} $*
     LATEST_VERSION=$(aws s3api list-object-versions --bucket ${AWS_S3_BUCKET} --prefix requirements/requirements.txt --query 'Versions[?IsLatest].[VersionId]' --output text)
     echo "Updating MWAA requirements version to ${LATEST_VERSION}"
-    aws mwaa update-environment --name ${AWS_MWAA_ENVIRONMENT} --requirements-s3-object-version ${LATEST_VERSION}
+    aws mwaa update-environment --name "${AWS_MWAA_ENVIRONMENT}" --requirements-s3-object-version "${LATEST_VERSION}"
 else
   if [ "`aws s3 ls s3://$AWS_S3_BUCKET/requirements/`" != "" ]; then
       echo "Remove requirements folder started"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-alias aws='awsv2'
+aws --version
 
 if [ -z "$AWS_S3_BUCKET" ]; then
   echo "AWS_S3_BUCKET is not set. Quitting."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,6 @@
 set -e
 
 alias aws='awsv2'
-aws --install
 
 if [ -z "$AWS_S3_BUCKET" ]; then
   echo "AWS_S3_BUCKET is not set. Quitting."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+alias aws='awsv2'
+
 if [ -z "$AWS_S3_BUCKET" ]; then
   echo "AWS_S3_BUCKET is not set. Quitting."
   exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ if [ -d "$SOURCE_DIR/requirements" ]; then
     aws s3 sync ${SOURCE_DIR}/requirements s3://${AWS_S3_BUCKET}/requirements --exact-timestamps --delete --region ${AWS_DEFAULT_REGION} $*
     LATEST_VERSION=$(aws s3api list-object-versions --bucket ${AWS_S3_BUCKET} --prefix requirements/requirements.txt --query 'Versions[?IsLatest].[VersionId]' --output text)
     echo "Updating MWAA requirements version to ${LATEST_VERSION}"
-    aws mwaa update-environment --name "${AWS_MWAA_ENVIRONMENT}" --requirements-s3-object-version "${LATEST_VERSION}" --profile default --region ${AWS_DEFAULT_REGION}
+    aws mwaa update-environment --name "${AWS_MWAA_ENVIRONMENT}" --requirements-s3-object-version "${LATEST_VERSION}" --region ${AWS_DEFAULT_REGION}
 else
   if [ "`aws s3 ls s3://$AWS_S3_BUCKET/requirements/`" != "" ]; then
       echo "Remove requirements folder started"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ if [ -d "$SOURCE_DIR/requirements" ]; then
     aws s3 sync ${SOURCE_DIR}/requirements s3://${AWS_S3_BUCKET}/requirements --exact-timestamps --delete --region ${AWS_DEFAULT_REGION} $*
     LATEST_VERSION=$(aws s3api list-object-versions --bucket ${AWS_S3_BUCKET} --prefix requirements/requirements.txt --query 'Versions[?IsLatest].[VersionId]' --output text)
     echo "Updating MWAA requirements version to ${LATEST_VERSION}"
-    aws mwaa update-environment --name "${AWS_MWAA_ENVIRONMENT}" --requirements-s3-object-version "${LATEST_VERSION}"
+    aws mwaa update-environment --name "${AWS_MWAA_ENVIRONMENT}" --requirements-s3-object-version "${LATEST_VERSION}" --profile default --region ${AWS_DEFAULT_REGION}
 else
   if [ "`aws s3 ls s3://$AWS_S3_BUCKET/requirements/`" != "" ]; then
       echo "Remove requirements folder started"


### PR DESCRIPTION
# Problem

The original  turnerlabs/s3-sync-airflow-action repo didn't update the MWAA requirements version when the requirements were updated.

# Solution

Fork the repo and modify it to update the requirements version.

# Verification

Used this branch in an `airflow` PR https://github.com/PromiseNetwork/airflow/pull/34/files. The requirements version is updated successfully -- https://github.com/PromiseNetwork/airflow/runs/4739601841?check_suite_focus=true
